### PR TITLE
[#6] 컴바인 이벤트 단방향 설계를 위한 추가 API 구현

### DIFF
--- a/MyLuxury/Presentation/Sources/Presentation/Home/View/HomeContents/HomeEditorRecommend/HomeEditorRecommendCollectionView.swift
+++ b/MyLuxury/Presentation/Sources/Presentation/Home/View/HomeContents/HomeEditorRecommend/HomeEditorRecommendCollectionView.swift
@@ -114,6 +114,6 @@ extension HomeEditorRecommendCollectionView: UICollectionViewDataSource, UIColle
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let post = postData[indexPath.row]
-        homeVM.input.send(.postTapped(post))
+        homeVM.sendInputEvent(input: .postTapped(post))
     }
 }

--- a/MyLuxury/Presentation/Sources/Presentation/Home/View/HomeContents/HomeGrid/HomeGridCollectionView.swift
+++ b/MyLuxury/Presentation/Sources/Presentation/Home/View/HomeContents/HomeGrid/HomeGridCollectionView.swift
@@ -101,6 +101,6 @@ extension HomeGridCollectionView: UICollectionViewDataSource, UICollectionViewDe
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let post = postData[indexPath.row]
-        homeVM.input.send(.postTapped(post))
+        homeVM.sendInputEvent(input: .postTapped(post))
     }
 }

--- a/MyLuxury/Presentation/Sources/Presentation/Home/View/HomeContents/HomeHorizontalCollection/HomeHorizontalCollectionView.swift
+++ b/MyLuxury/Presentation/Sources/Presentation/Home/View/HomeContents/HomeHorizontalCollection/HomeHorizontalCollectionView.swift
@@ -102,6 +102,6 @@ extension HomeHorizontalCollectionView: UICollectionViewDataSource, UICollection
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let post = postData[indexPath.row]
-        homeVM.input.send(.postTapped(post))
+        homeVM.sendInputEvent(input: .postTapped(post))
     }
 }

--- a/MyLuxury/Presentation/Sources/Presentation/Home/View/HomeContents/HomeTodayPick/HomeTodayPickView.swift
+++ b/MyLuxury/Presentation/Sources/Presentation/Home/View/HomeContents/HomeTodayPick/HomeTodayPickView.swift
@@ -102,6 +102,6 @@ final class HomeTodayPickView: UIView, HomeContentsSectionView {
     }
     
     @objc func postTapped() {
-        homeVM.input.send(.postTapped(postData))
+        homeVM.sendInputEvent(input: .postTapped(postData))
     }
 }

--- a/MyLuxury/Presentation/Sources/Presentation/Home/ViewController/HomeViewController.swift
+++ b/MyLuxury/Presentation/Sources/Presentation/Home/ViewController/HomeViewController.swift
@@ -17,14 +17,12 @@ class HomeViewController: UIViewController {
     private let rootView: HomeMainView
     weak var delegate: HomeControllerDelegate?
     private let homeVM: HomeViewModel
-    private let input: PassthroughSubject<HomeViewModel.Input, Never>
     private var cancellabes = Set<AnyCancellable>()
     
     init(homeVM: HomeViewModel) {
         print("HomeViewController init")
         self.homeVM = homeVM
         self.rootView = HomeMainView(homeVM: homeVM)
-        self.input = homeVM.input
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -46,7 +44,7 @@ class HomeViewController: UIViewController {
         super.viewDidLoad()
         
         bindData()
-        input.send(.viewLoaded)
+        homeVM.sendInputEvent(input: .viewLoaded)
     }
     
     /// 세 번째로 호출
@@ -58,7 +56,7 @@ class HomeViewController: UIViewController {
 //    }
     
     private func bindData() {
-        let output = homeVM.transform(input: input.eraseToAnyPublisher())
+        let output = homeVM.transform()
         output
             .receive(on: DispatchQueue.main)
             .sink { [weak self] event in

--- a/MyLuxury/Presentation/Sources/Presentation/Post/View/PostView.swift
+++ b/MyLuxury/Presentation/Sources/Presentation/Post/View/PostView.swift
@@ -106,7 +106,7 @@ final class PostView: UIView {
     
     @objc
     private func goToBackScreen() {
-        self.postVM.input.send(.goBackBtnTapped)
+        self.postVM.sendInputEvent(input: .goBackBtnTapped)
     }
 }
 

--- a/MyLuxury/Presentation/Sources/Presentation/Post/ViewController/PostViewController.swift
+++ b/MyLuxury/Presentation/Sources/Presentation/Post/ViewController/PostViewController.swift
@@ -17,7 +17,6 @@ final class PostViewController: UIViewController {
     private let rootView: PostView
     weak var delegate: PostViewControllerDelegate?
     private let postVM: PostViewModel
-    private let input: PassthroughSubject<PostViewModel.Input, Never>
     private var cancellable = Set<AnyCancellable>()
     
     
@@ -25,7 +24,6 @@ final class PostViewController: UIViewController {
         print("PostViewController init")
         self.postVM = postVM
         self.rootView = PostView(postVM: self.postVM)
-        self.input = postVM.input
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -58,11 +56,12 @@ final class PostViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        input.send(.viewLoaded)
+//        input.send(.viewLoaded)
+        postVM.sendInputEvent(input: .viewLoaded)
     }
     
     private func bindData() {
-        let output = postVM.transform(input: input.eraseToAnyPublisher())
+        let output = postVM.transform()
         output
             .receive(on: DispatchQueue.main)
             .sink { [weak self] event in

--- a/MyLuxury/Presentation/Sources/Presentation/Post/ViewModel/PostViewModel.swift
+++ b/MyLuxury/Presentation/Sources/Presentation/Post/ViewModel/PostViewModel.swift
@@ -11,8 +11,8 @@ import Combine
 
 class PostViewModel {
     let postUseCase: PostUseCase
-    let output: PassthroughSubject<Output, Never> = .init()
-    let input: PassthroughSubject<Input, Never> = .init()
+    private let output: PassthroughSubject<Output, Never> = .init()
+    private let input: PassthroughSubject<Input, Never> = .init()
     var cancellables = Set<AnyCancellable>()
     
     let postId: String
@@ -28,7 +28,8 @@ class PostViewModel {
         print("PostViewModel deinit")
     }
     
-    func transform(input: AnyPublisher<Input, Never>) -> AnyPublisher<Output, Never> {
+    func transform() -> AnyPublisher<Output, Never> {
+        let input = input.eraseToAnyPublisher()
         input.sink { [weak self] event in
             guard let self = self else { return }
             switch event {
@@ -39,6 +40,15 @@ class PostViewModel {
             }
         }.store(in: &cancellables)
         return output.eraseToAnyPublisher()
+    }
+    
+    func sendInputEvent(input: Input) {
+        switch input {
+        case .goBackBtnTapped:
+            self.input.send(.goBackBtnTapped)
+        case .viewLoaded:
+            self.input.send(.viewLoaded)
+        }
     }
 
     func getPostOneData(postId: String) {

--- a/MyLuxury/Presentation/Sources/Presentation/Search/View/SearchGrid/SearchGridView.swift
+++ b/MyLuxury/Presentation/Sources/Presentation/Search/View/SearchGrid/SearchGridView.swift
@@ -100,8 +100,7 @@ final class SearchGridView: UIView {
     }
     
     @objc private func searchBarTapped() {
-        // 이건 한 번만 호출되는 중
-        searchVM.input.send(.searchBarTapped)
+        searchVM.sendInputEvent(input: .searchBarTapped)
     }
 }
 
@@ -121,7 +120,7 @@ extension SearchGridView: UICollectionViewDataSource, UICollectionViewDelegateFl
     
     func collectionView(_ collectionView: UICollectionView, didSelectItemAt indexPath: IndexPath) {
         let post = posts[indexPath.row]
-        searchVM.input.send(.postTapped(post))
+        searchVM.sendInputEvent(input: .postTapped(post))
     }
     
     /// 각 셀의 크기를 동적으로 지정

--- a/MyLuxury/Presentation/Sources/Presentation/Search/View/SearchResult/SearchResultView.swift
+++ b/MyLuxury/Presentation/Sources/Presentation/Search/View/SearchResult/SearchResultView.swift
@@ -95,7 +95,7 @@ final class SearchResultView: UIView, UITextFieldDelegate {
     
     @objc
     private func cancelTextTapped() {
-        searchVM.input.send(.searchBarCancelTapped)
+        searchVM.sendInputEvent(input: .searchBarCancelTapped)
     }
     
     @objc

--- a/MyLuxury/Presentation/Sources/Presentation/Search/ViewController/SearchGridViewController.swift
+++ b/MyLuxury/Presentation/Sources/Presentation/Search/ViewController/SearchGridViewController.swift
@@ -18,14 +18,12 @@ class SearchGridViewController: UIViewController {
     private let rootView: SearchGridView
     private let searchVM: SearchViewModel
     weak var delegate: SearchGridViewControllerDelegate?
-    private let input: PassthroughSubject<SearchViewModel.Input, Never>
     private var cancellables = Set<AnyCancellable>()
     
     init(searchVM: SearchViewModel) {
         print("SearchGridViewController init")
         self.searchVM = searchVM
         self.rootView = SearchGridView(searchVM: searchVM)
-        self.input = searchVM.input
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -48,11 +46,11 @@ class SearchGridViewController: UIViewController {
     
     override func viewDidAppear(_ animated: Bool) {
         super.viewDidAppear(animated)
-        searchVM.input.send(.searchGridViewLoaded)
+        searchVM.sendInputEvent(input: .searchGridViewLoaded)
     }
     
     private func bindData() {
-        let output = searchVM.transform(input: input.eraseToAnyPublisher())
+        let output = searchVM.transform()
         output
             .receive(on: DispatchQueue.main)
             .sink { [weak self] event in

--- a/MyLuxury/Presentation/Sources/Presentation/Search/ViewController/SearchResultViewController.swift
+++ b/MyLuxury/Presentation/Sources/Presentation/Search/ViewController/SearchResultViewController.swift
@@ -17,14 +17,12 @@ class SearchResultViewController: UIViewController {
     private let rootView: SearchResultView
     private let searchVM: SearchViewModel
     weak var delegate: SearchResultViewControllerDelegate?
-    private let input: PassthroughSubject<SearchViewModel.Input, Never>
     private var cancellables = Set<AnyCancellable>()
     
     init(searchVM: SearchViewModel) {
         print("SearchResultViewController init")
         self.searchVM = searchVM
         self.rootView = SearchResultView(searchVM: searchVM)
-        self.input = searchVM.input
         super.init(nibName: nil, bundle: nil)
     }
     
@@ -50,7 +48,9 @@ class SearchResultViewController: UIViewController {
     }
     
     private func bindData() {
-        let output = searchVM.output
+        /// 두 개의 VC가 하나의 VM을 동시에 사용하고 있으므로
+        /// 이중으로 구독 등록을 하지 않기 위해서 이곳에서는 searchVM.transform()을 실행하지 않습니다.
+        let output = searchVM.getOutputInstance()
         output
             .receive(on: DispatchQueue.main)
             .sink { [weak self] event in


### PR DESCRIPTION
- ViewModel 안에서 생성된 input, output 인스턴스에 외부에서 접근하지 못하도록 private으로 설정하였습니다. 
- view에서 퍼블리셔에 직접 접근하지 않고도  Input 사용자 이벤트를 전달할 수 있도록 Input 열거형을 파라미터로 받는 새로운 메소드 API를 정의했습니다.